### PR TITLE
Fix p7 get skeleton and testing model

### DIFF
--- a/src_asl2gloss/create_own_dataset/p7_get_skeleton_and_landmark_for_back_end.py
+++ b/src_asl2gloss/create_own_dataset/p7_get_skeleton_and_landmark_for_back_end.py
@@ -12,7 +12,7 @@ from sys import stderr
 PROJ_ROOT: str= str(Path(__file__).parent.parent.parent)
 
 MODEL_DIR: str= str(Path(PROJ_ROOT)/"model")
-MODEL_FILE_LIST: tuple= ("aslvid2gloss_v30.keras",)
+MODEL_FILE_LIST: tuple= ("aslvid2gloss_v25.keras", "aslvid2gloss_v30.keras",)
 ASL2GLOSS_MODEL_LIST: tuple= tuple(load_model(Path(MODEL_DIR)/el) for el in MODEL_FILE_LIST)
 
 GLASL_DIR: str= str(Path(PROJ_ROOT)/"dataset"/"glasl")
@@ -452,27 +452,28 @@ if __name__=='__main__':
                 KEY_V_IMGs_ID: [],
             })
             for model_idx in range(len(MODEL_FILE_LIST)):
-                landmark_dataset_elements: list= []
-                if len(a_gloss_video[KEY_V_IMGs_ID_origin])<=QUANTITY_FRAME:
-                    landmark_dataset_elements.append(getLessThanOrEqual_landmark_allHasHand(
-                        lmark_=a_gloss_video,
-                        landmark_directory=LANDMARK_origin,
-                    ))
-                else:
-                    landmark_dataset_elements= getGreaterThan_landmark_allHasHand(
-                        lmark_=a_gloss_video,
-                        landmark_directory=LANDMARK_origin,
+                if a_gloss_video[KEY_G_ID]<ASL2GLOSS_MODEL_LIST[model_idx].output_shape[-1]:
+                    landmark_dataset_elements: list= []
+                    if len(a_gloss_video[KEY_V_IMGs_ID_origin])<=QUANTITY_FRAME:
+                        landmark_dataset_elements.append(getLessThanOrEqual_landmark_allHasHand(
+                            lmark_=a_gloss_video,
+                            landmark_directory=LANDMARK_origin,
+                        ))
+                    else:
+                        landmark_dataset_elements= getGreaterThan_landmark_allHasHand(
+                            lmark_=a_gloss_video,
+                            landmark_directory=LANDMARK_origin,
+                        )
+                    quantity_of_elements: int= array(landmark_dataset_elements).shape[0]
+                    modelPredict= ASL2GLOSS_MODEL_LIST[model_idx].predict(
+                        x=array(landmark_dataset_elements, dtype=float32),
+                        batch_size=quantity_of_elements,
                     )
-                quantity_of_elements: int= array(landmark_dataset_elements).shape[0]
-                modelPredict= ASL2GLOSS_MODEL_LIST[model_idx].predict(
-                    x=array(landmark_dataset_elements, dtype=float32),
-                    batch_size=quantity_of_elements,
-                )
-                modelPredict= npsum(modelPredict, axis=0) / quantity_of_elements
-                glasl_LANDMARK[ data_split ][-1][KEY_MODEL_ACC].append({
-                    'model_file': MODEL_FILE_LIST[model_idx],
-                    'accuracy': tuple(modelPredict.tolist())
-                })
+                    modelPredict= npsum(modelPredict, axis=0) / quantity_of_elements
+                    glasl_LANDMARK[ data_split ][-1][KEY_MODEL_ACC].append({
+                        'model_file': MODEL_FILE_LIST[model_idx],
+                        'accuracy': tuple(modelPredict.tolist())
+                    })
             for i in range(imgs_skeleton.shape[0]): # each video has many images, now for each images
                 file2create: str= f"{a_gloss_video[KEY_V_ID]}_{a_gloss_video[KEY_V_IMGs_ID_origin][i]['file'][:-4]}"
                 filename_abs_landmark_w: str= f"{Path(LANDMARK_dir) / file2create}.npy"

--- a/src_asl2gloss/test_model/model_v23.py
+++ b/src_asl2gloss/test_model/model_v23.py
@@ -86,8 +86,8 @@ if __name__=="__main__":
     glasl_landmark: dict= {}
     with open(f"{PROJ_ROOT}dataset/glasl/glasl.annotation.landmark.json", 'r') as f:
         glasl_landmark= loadjson(f)
-    TRAIN_GLOSS: int= 10
     model: Any= load_model(f"{PROJ_ROOT}model/aslvid2gloss_v23.keras")
+    TRAIN_GLOSS: int= model.output_shape[-1] # 10 categories
 
 
     batch: int= 4
@@ -112,7 +112,7 @@ if __name__=="__main__":
         batch_vid_lm: list= []
         batch_gloss: list= []
         i: int= 0
-        while i<len(glasl_landmark[tvt_idv]):
+        while i<len(glasl_landmark[tvt_idv]) and glasl_landmark[tvt_idv][i]['gloss_id']<TRAIN_GLOSS:
             if len(batch_vid_lm)<batch:
                 tmp= []
                 if len(glasl_landmark[tvt_idv][i]['landmark'])<=QUANTITY_FRAME:
@@ -159,7 +159,7 @@ if __name__=="__main__":
         print(f"__________________________ {tvt_idv} ____")
         q_correct: int= 0
         q_vid: int= 0
-        for g_id in range(10):
+        for g_id in range(TRAIN_GLOSS):
             q_correct+= details[tvt_idv]['correct'][g_id]
             q_vid+= details[tvt_idv]['total_vid'][g_id]
             print(f"{g_id}: {glasl_landmark[KEY_ID2G][g_id]} --> {details[tvt_idv]['correct'][g_id]}/{details[tvt_idv]['total_vid'][g_id]}")

--- a/src_asl2gloss/test_model/model_v24.py
+++ b/src_asl2gloss/test_model/model_v24.py
@@ -86,8 +86,8 @@ if __name__=="__main__":
     glasl_landmark: dict= {}
     with open(f"{PROJ_ROOT}dataset/glasl/glasl.annotation.landmark.json", 'r') as f:
         glasl_landmark= loadjson(f)
-    TRAIN_GLOSS: int= 10
     model: Any= load_model(f"{PROJ_ROOT}model/aslvid2gloss_v24.keras")
+    TRAIN_GLOSS: int= model.output_shape[-1] # 10 categories
 
 
     batch: int= 4
@@ -112,7 +112,7 @@ if __name__=="__main__":
         batch_vid_lm: list= []
         batch_gloss: list= []
         i: int= 0
-        while i<len(glasl_landmark[tvt_idv]):
+        while i<len(glasl_landmark[tvt_idv]) and glasl_landmark[tvt_idv][i]['gloss_id']<TRAIN_GLOSS:
             if len(batch_vid_lm)<batch:
                 tmp= []
                 if len(glasl_landmark[tvt_idv][i]['landmark'])<=QUANTITY_FRAME:
@@ -159,7 +159,7 @@ if __name__=="__main__":
         print(f"__________________________ {tvt_idv} ____")
         q_correct: int= 0
         q_vid: int= 0
-        for g_id in range(10):
+        for g_id in range(TRAIN_GLOSS):
             q_correct+= details[tvt_idv]['correct'][g_id]
             q_vid+= details[tvt_idv]['total_vid'][g_id]
             print(f"{g_id}: {glasl_landmark[KEY_ID2G][g_id]} --> {details[tvt_idv]['correct'][g_id]}/{details[tvt_idv]['total_vid'][g_id]}")

--- a/src_asl2gloss/test_model/model_v25.py
+++ b/src_asl2gloss/test_model/model_v25.py
@@ -86,8 +86,8 @@ if __name__=="__main__":
     glasl_landmark: dict= {}
     with open(f"{PROJ_ROOT}dataset/glasl/glasl.annotation.landmark.json", 'r') as f:
         glasl_landmark= loadjson(f)
-    TRAIN_GLOSS: int= 10
     model: Any= load_model(f"{PROJ_ROOT}model/aslvid2gloss_v25.keras")
+    TRAIN_GLOSS: int= model.output_shape[-1] # 10 categories
 
 
     batch: int= 4
@@ -112,7 +112,7 @@ if __name__=="__main__":
         batch_vid_lm: list= []
         batch_gloss: list= []
         i: int= 0
-        while i<len(glasl_landmark[tvt_idv]):
+        while i<len(glasl_landmark[tvt_idv]) and glasl_landmark[tvt_idv][i]['gloss_id']<TRAIN_GLOSS:
             if len(batch_vid_lm)<batch:
                 tmp= []
                 if len(glasl_landmark[tvt_idv][i]['landmark'])<=QUANTITY_FRAME:
@@ -159,7 +159,7 @@ if __name__=="__main__":
         print(f"__________________________ {tvt_idv} ____")
         q_correct: int= 0
         q_vid: int= 0
-        for g_id in range(10):
+        for g_id in range(TRAIN_GLOSS):
             q_correct+= details[tvt_idv]['correct'][g_id]
             q_vid+= details[tvt_idv]['total_vid'][g_id]
             print(f"{g_id}: {glasl_landmark[KEY_ID2G][g_id]} --> {details[tvt_idv]['correct'][g_id]}/{details[tvt_idv]['total_vid'][g_id]}")

--- a/src_asl2gloss/test_model/model_v26.py
+++ b/src_asl2gloss/test_model/model_v26.py
@@ -86,8 +86,8 @@ if __name__=="__main__":
     glasl_landmark: dict= {}
     with open(f"{PROJ_ROOT}dataset/glasl/glasl.annotation.landmark.json", 'r') as f:
         glasl_landmark= loadjson(f)
-    TRAIN_GLOSS: int= 10
     model: Any= load_model(f"{PROJ_ROOT}model/aslvid2gloss_v26.keras")
+    TRAIN_GLOSS: int= model.output_shape[-1] # 10 categories
 
 
     batch: int= 4
@@ -112,7 +112,7 @@ if __name__=="__main__":
         batch_vid_lm: list= []
         batch_gloss: list= []
         i: int= 0
-        while i<len(glasl_landmark[tvt_idv]):
+        while i<len(glasl_landmark[tvt_idv]) and glasl_landmark[tvt_idv][i]['gloss_id']<TRAIN_GLOSS:
             if len(batch_vid_lm)<batch:
                 tmp= []
                 if len(glasl_landmark[tvt_idv][i]['landmark'])<=QUANTITY_FRAME:
@@ -159,7 +159,7 @@ if __name__=="__main__":
         print(f"__________________________ {tvt_idv} ____")
         q_correct: int= 0
         q_vid: int= 0
-        for g_id in range(10):
+        for g_id in range(TRAIN_GLOSS):
             q_correct+= details[tvt_idv]['correct'][g_id]
             q_vid+= details[tvt_idv]['total_vid'][g_id]
             print(f"{g_id}: {glasl_landmark[KEY_ID2G][g_id]} --> {details[tvt_idv]['correct'][g_id]}/{details[tvt_idv]['total_vid'][g_id]}")

--- a/src_asl2gloss/test_model/model_v27.py
+++ b/src_asl2gloss/test_model/model_v27.py
@@ -86,8 +86,8 @@ if __name__=="__main__":
     glasl_landmark: dict= {}
     with open(f"{PROJ_ROOT}dataset/glasl/glasl.annotation.landmark.json", 'r') as f:
         glasl_landmark= loadjson(f)
-    TRAIN_GLOSS: int= 10
     model: Any= load_model(f"{PROJ_ROOT}model/aslvid2gloss_v27.keras")
+    TRAIN_GLOSS: int= model.output_shape[-1] # 10 categories
 
 
     batch: int= 4
@@ -112,7 +112,7 @@ if __name__=="__main__":
         batch_vid_lm: list= []
         batch_gloss: list= []
         i: int= 0
-        while i<len(glasl_landmark[tvt_idv]):
+        while i<len(glasl_landmark[tvt_idv]) and glasl_landmark[tvt_idv][i]['gloss_id']<TRAIN_GLOSS:
             if len(batch_vid_lm)<batch:
                 tmp= []
                 if len(glasl_landmark[tvt_idv][i]['landmark'])<=QUANTITY_FRAME:
@@ -159,7 +159,7 @@ if __name__=="__main__":
         print(f"__________________________ {tvt_idv} ____")
         q_correct: int= 0
         q_vid: int= 0
-        for g_id in range(10):
+        for g_id in range(TRAIN_GLOSS):
             q_correct+= details[tvt_idv]['correct'][g_id]
             q_vid+= details[tvt_idv]['total_vid'][g_id]
             print(f"{g_id}: {glasl_landmark[KEY_ID2G][g_id]} --> {details[tvt_idv]['correct'][g_id]}/{details[tvt_idv]['total_vid'][g_id]}")

--- a/src_asl2gloss/test_model/model_v28.py
+++ b/src_asl2gloss/test_model/model_v28.py
@@ -86,8 +86,8 @@ if __name__=="__main__":
     glasl_landmark: dict= {}
     with open(f"{PROJ_ROOT}dataset/glasl/glasl.annotation.landmark.json", 'r') as f:
         glasl_landmark= loadjson(f)
-    TRAIN_GLOSS: int= 22
     model: Any= load_model(f"{PROJ_ROOT}model/aslvid2gloss_v28.keras")
+    TRAIN_GLOSS: int= model.output_shape[-1] # 22 categories
 
 
     batch: int= 4
@@ -112,7 +112,7 @@ if __name__=="__main__":
         batch_vid_lm: list= []
         batch_gloss: list= []
         i: int= 0
-        while i<len(glasl_landmark[tvt_idv]):
+        while i<len(glasl_landmark[tvt_idv]) and glasl_landmark[tvt_idv][i]['gloss_id']<TRAIN_GLOSS:
             if len(batch_vid_lm)<batch:
                 tmp= []
                 if len(glasl_landmark[tvt_idv][i]['landmark'])<=QUANTITY_FRAME:

--- a/src_asl2gloss/test_model/model_v29.py
+++ b/src_asl2gloss/test_model/model_v29.py
@@ -86,8 +86,8 @@ if __name__=="__main__":
     glasl_landmark: dict= {}
     with open(f"{PROJ_ROOT}dataset/glasl/glasl.annotation.landmark.json", 'r') as f:
         glasl_landmark= loadjson(f)
-    TRAIN_GLOSS: int= 22
     model: Any= load_model(f"{PROJ_ROOT}model/aslvid2gloss_v29.keras")
+    TRAIN_GLOSS: int= model.output_shape[-1] # 22 categories
 
 
     batch: int= 4
@@ -112,7 +112,7 @@ if __name__=="__main__":
         batch_vid_lm: list= []
         batch_gloss: list= []
         i: int= 0
-        while i<len(glasl_landmark[tvt_idv]):
+        while i<len(glasl_landmark[tvt_idv]) and glasl_landmark[tvt_idv][i]['gloss_id']<TRAIN_GLOSS:
             if len(batch_vid_lm)<batch:
                 tmp= []
                 if len(glasl_landmark[tvt_idv][i]['landmark'])<=QUANTITY_FRAME:

--- a/src_asl2gloss/test_model/model_v30.py
+++ b/src_asl2gloss/test_model/model_v30.py
@@ -86,8 +86,8 @@ if __name__=="__main__":
     glasl_landmark: dict= {}
     with open(f"{PROJ_ROOT}dataset/glasl/glasl.annotation.landmark.json", 'r') as f:
         glasl_landmark= loadjson(f)
-    TRAIN_GLOSS: int= 22
     model: Any= load_model(f"{PROJ_ROOT}model/aslvid2gloss_v30.keras")
+    TRAIN_GLOSS: int= model.output_shape[-1] # 22 categories
 
 
     batch: int= 4
@@ -112,7 +112,7 @@ if __name__=="__main__":
         batch_vid_lm: list= []
         batch_gloss: list= []
         i: int= 0
-        while i<len(glasl_landmark[tvt_idv]):
+        while i<len(glasl_landmark[tvt_idv]) and glasl_landmark[tvt_idv][i]['gloss_id']<TRAIN_GLOSS:
             if len(batch_vid_lm)<batch:
                 tmp= []
                 if len(glasl_landmark[tvt_idv][i]['landmark'])<=QUANTITY_FRAME:


### PR DESCRIPTION
fixed testing for model v23 to v30:
- src_asl2gloss/test_model/model_v23.py
- src_asl2gloss/test_model/model_v24.py
- src_asl2gloss/test_model/model_v25.py
- src_asl2gloss/test_model/model_v26.py
- src_asl2gloss/test_model/model_v27.py
- src_asl2gloss/test_model/model_v28.py
- src_asl2gloss/test_model/model_v29.py
- src_asl2gloss/test_model/model_v30.py

made `src_asl2gloss/create_own_dataset/p7_get_skeleton_and_landmark_for_back_end.py` to now include model v25 and model v30. the best 2 models

model v25 capable for gloss 1 to gloss 10
model v30 capable for gloss 1 to gloss 22